### PR TITLE
Supporting Real Time updates for Recurring Events on iOS.

### DIFF
--- a/common/DeviceCalendarPlugin.swift
+++ b/common/DeviceCalendarPlugin.swift
@@ -78,6 +78,8 @@ public class DeviceCalendarPlugin: DeviceCalendarPluginBase, FlutterPlugin {
         let reminders: [CalendarReminder]
         let availability: Availability?
         let eventStatus: EventStatus?
+        let eventIsDetached: Bool
+        let eventOccurrenceDate: Int64
     }
 
     struct RecurrenceRule: Codable {
@@ -579,7 +581,9 @@ public class DeviceCalendarPlugin: DeviceCalendarPluginBase, FlutterPlugin {
             organizer: convertEkParticipantToAttendee(ekParticipant: ekEvent.organizer),
             reminders: reminders,
             availability: convertEkEventAvailability(ekEventAvailability: ekEvent.availability),
-            eventStatus: convertEkEventStatus(ekEventStatus: ekEvent.status)
+            eventStatus: convertEkEventStatus(ekEventStatus: ekEvent.status),
+            eventIsDetached: ekEvent.isDetached,
+            eventOccurrenceDate: Int64(ekEvent.occurrenceDate.millisecondsSinceEpoch)
         )
 
         return event
@@ -633,6 +637,12 @@ public class DeviceCalendarPlugin: DeviceCalendarPluginBase, FlutterPlugin {
     
     private func parseEKRecurrenceRules(_ ekEvent: EKEvent) -> RecurrenceRule? {
         var recurrenceRule: RecurrenceRule?
+
+        // MZ - Added for debugging purposes
+        if ekEvent.isDetached {
+            print("Debug: The event with ID \(ekEvent.eventIdentifier ?? "unknown") is a detached occurrence from its recurrence rule.")
+        }
+
         if ekEvent.hasRecurrenceRules {
             let ekRecurrenceRule = ekEvent.recurrenceRules![0]
             var frequency: String
@@ -1196,6 +1206,7 @@ public class DeviceCalendarPlugin: DeviceCalendarPluginBase, FlutterPlugin {
             let jsonEncoder = JSONEncoder()
             let jsonData = try jsonEncoder.encode(codable)
             let jsonString = String(data: jsonData, encoding: .utf8)
+            print("JSON: \(jsonString ?? "nil")")
             result(jsonString)
         } catch {
             result(FlutterError(code: genericError, message: error.localizedDescription, details: nil))

--- a/lib/src/device_calendar.dart
+++ b/lib/src/device_calendar.dart
@@ -123,8 +123,9 @@ class DeviceCalendarPlugin {
       ),*/
         evaluateResponse: (rawData) => UnmodifiableListView(
               json.decode(rawData).map<Event>((decodedEvent) {
-                // debugPrint(
-                //     "JSON_RRULE: ${decodedEvent['recurrenceRule']}, ${(decodedEvent['recurrenceRule']['byday'])}");
+                // MZ - Added for debugging purposes
+                // debugPrint("RAW_DATA: $decodedEvent");
+
                 return Event.fromJson(decodedEvent);
               }),
             ));

--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -51,6 +51,13 @@ class Event {
   /// Indicates if this event is of confirmed, canceled, tentative or none status
   EventStatus? status;
 
+  /// Indicates if this event is detached from the recurring event series (For iOS only)
+  bool? eventIsDetached;
+
+  /// Indicates when the original occurrence of the event starts
+  /// This is only used when the event is a detached event from a recurring event series (For iOS only)
+  TZDateTime? eventOriginalOccurrenceDate;
+
   ///Note for development:
   ///
   ///JSON field names are coded in dart, swift and kotlin to facilitate data exchange.
@@ -74,12 +81,14 @@ class Event {
       this.location,
       this.url,
       this.allDay = false,
-      this.status});
+      this.status,
+      this.eventIsDetached = false,
+      this.eventOriginalOccurrenceDate});
 
   ///Get Event from JSON.
   ///
   ///Sample JSON:
-  ///{calendarId: 00, eventId: 0000, eventTitle: Sample Event, eventDescription: This is a sample event, eventStartDate: 1563719400000, eventStartTimeZone: Asia/Hong_Kong, eventEndDate: 1640532600000, eventEndTimeZone: Asia/Hong_Kong, eventAllDay: false, eventLocation: Yuenlong Station, eventURL: null, availability: BUSY, attendees: [{name: commonfolk, emailAddress: total.loss@hong.com, role: 1, isOrganizer: false, attendanceStatus: 3}], reminders: [{minutes: 39}]}
+  ///{calendarId: 00, eventId: 0000, eventTitle: Sample Event, eventDescription: This is a sample event, eventStartDate: 1563719400000, eventStartTimeZone: Asia/Hong_Kong, eventEndDate: 1640532600000, eventEndTimeZone: Asia/Hong_Kong, eventAllDay: false, eventLocation: Yuenlong Station, eventURL: null, availability: BUSY, attendees: [{name: commonfolk, emailAddress: total.loss@hong.com, role: 1, isOrganizer: false, attendanceStatus: 3}], eventOccurrenceDate: 1563719400000, eventIsDetached: false, reminders: [{minutes: 39}]}
   Event.fromJson(Map<String, dynamic>? json) {
     if (json == null) {
       throw ArgumentError(ErrorMessages.fromJsonMapIsNull);
@@ -171,6 +180,14 @@ class Event {
       }
     }
 
+    eventIsDetached = json['eventIsDetached'];
+
+    var occurrenceDateTimestamp = json['eventOccurrenceDate'];
+    eventOriginalOccurrenceDate = occurrenceDateTimestamp != null
+        ? TZDateTime.fromMillisecondsSinceEpoch(
+            startTimeZone, occurrenceDateTimestamp)
+        : null;
+
     if (json['recurrenceRule'] != null) {
       // debugPrint(
       //     "EVENT_MODEL: $title; START: $start, END: $end RRULE = ${json['recurrenceRule']}");
@@ -253,6 +270,9 @@ class Event {
     data['eventURL'] = url?.data?.contentText;
     data['availability'] = availability.enumToString;
     data['eventStatus'] = status?.enumToString;
+    data['eventIsDetached'] = eventIsDetached;
+    data['eventOriginalOccurrenceDate'] =
+        eventOriginalOccurrenceDate?.millisecondsSinceEpoch;
 
     if (attendees != null) {
       data['attendees'] = attendees?.map((a) => a?.toJson()).toList();


### PR DESCRIPTION
Manny's remarks from Slack, copied by Luke:

(corresponding tf repo PR: https://github.com/TimeFinderApp/timefinder_app/pull/656)

> I have completed the fixes for issues 3 and 4 outlined in the [document](https://docs.google.com/document/d/1B9Pt1ebiKWdypICsfVYDYCVUn1dIp-PsWL1UVwHU4CU/edit). We had to properly track deleted and delinked occurrences, utilizing properties in EventKit such as `isDetached` and `occurrenceDate`.
>
> After implementing several modifications to the `device_calendar` package and the Flutter side of the app, we can now track updates to recurring events in real time for each occurrence. Additionally, I made adjustments to ensure that recurring events sync properly, avoiding issues related to the window context (± 8 days). Now, the recurrence will utilize the earliest `startRecurrenceDate` and effectively track `RecurrenceExceptions`.
> 
> Additionally, I noticed that the issue mentioned in this ticket (https://linear.app/timefinder/issue/TF-915/calsync-duplicate-issue) appears to be related to issue 3 from the document. (So should be fixed).
>
> I have tested the fixes on iOS and Mac, and everything works as expected. I have not yet started work on the Android side fixes, as I need to conduct similar research to track deleted and delinked occurrences.