### PR TITLE
Fix RFC 5545 violations in recurrence rules from third-party calendar apps

### DIFF
--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -227,7 +227,9 @@ class Event {
         }
 
         if (json['recurrenceRule'] != null) {
-          recurrenceRule = RecurrenceRule.fromJson(json['recurrenceRule']);
+          // Sanitize the recurrence rule to handle malformed rules from third-party apps
+          final sanitizedRule = _sanitizeRecurrenceRule(json['recurrenceRule']);
+          recurrenceRule = RecurrenceRule.fromJson(sanitizedRule);
         }
       } catch (e, stackTrace) {
         FlutterError.reportError(FlutterErrorDetails(
@@ -346,5 +348,23 @@ class Event {
     } on LocationNotFoundException {
       return false;
     }
+  }
+
+  /// Sanitizes recurrence rule to handle malformed rules from third-party calendar apps
+  /// Following the "graceful degradation" approach similar to libical
+  static Map<String, dynamic> _sanitizeRecurrenceRule(Map<String, dynamic> rule) {
+    final sanitized = Map<String, dynamic>.from(rule);
+    final freq = sanitized['freq'] as String?;
+    
+    // Handle RFC 5545 violation: BYYEARDAY MUST NOT be specified for DAILY, WEEKLY, or MONTHLY
+    if (freq != null && ['DAILY', 'WEEKLY', 'MONTHLY'].contains(freq.toUpperCase())) {
+      if (sanitized.containsKey('byyearday')) {
+        print('WARNING: Removing BYYEARDAY from $freq recurrence rule (RFC 5545 violation)');
+        print('Event may have been created by third-party calendar app with relaxed validation');
+        sanitized.remove('byyearday');
+      }
+    }
+    
+    return sanitized;
   }
 }


### PR DESCRIPTION
## Summary
- Adds graceful degradation for RFC 5545 violations in recurrence rules from third-party calendar apps (like Fantastical)
- Sanitizes malformed recurrence rules before parsing to prevent crashes
- Preserves event functionality while maintaining RFC 5545 compliance

## Changes
- Added `_sanitizeRecurrenceRule()` method to Event class
- Removes problematic BYYEARDAY rules from DAILY/WEEKLY/MONTHLY frequencies
- Logs warnings for debugging while maintaining functionality

## Testing
- Fixes crashes with Fantastical events containing both BYMONTHDAY and BYYEARDAY
- Maintains correct monthly recurrence behavior